### PR TITLE
fix subAsset nullreference bug

### DIFF
--- a/Editor/SubAssetEditor.cs
+++ b/Editor/SubAssetEditor.cs
@@ -70,7 +70,7 @@ namespace Coffee.Editors
             // Find sub-assets.
             var assetPath = AssetDatabase.GetAssetPath(active);
             _subAssets = AssetDatabase.LoadAllAssetsAtPath(assetPath)
-                .Where(x => !(x is GameObject || x is Component) && x != _current && 0 == (x.hideFlags & HideFlags.HideInHierarchy))
+                .Where(x => x != null && !(x is GameObject || x is Component) && x != _current && 0 == (x.hideFlags & HideFlags.HideInHierarchy))
                 .Distinct()
                 .ToList();
 
@@ -78,6 +78,11 @@ namespace Coffee.Editors
             _referencingAssets.Clear();
             foreach (var o in AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(active)))
             {
+                if (o == null)
+                {
+                    continue;
+                }
+
                 var sp = new SerializedObject(o).GetIterator();
                 sp.Next(true);
 


### PR DESCRIPTION
In some case, AssetDatabase.LoadAllAssetsAtPath(assetPath) retrue a null scriptobject.
![Snipaste_2022-08-04_13-28-41](https://user-images.githubusercontent.com/15962980/182771397-857d2de1-eeda-4c5c-9528-64753d481f85.png)

