### PR TITLE
docs: update package.json author format

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/mob-sakai/SubAssetEditor.git"
   },
-  "author": "mob-sakai <sakai861104@gmail.com> (https://github.com/mob-sakai)",
+  "author": {
+    "name": "mob-sakai",
+    "email": "sakai861104@gmail.com",
+    "url": "https://github.com/mob-sakai"
+  },
   "keywords": [
     "editor"
   ],


### PR DESCRIPTION
## Description

The VRChat Package Manager is more picky about the author field in `package.json` than Unity itself, expecting only the object format. With this change, the package can be used directly as a VRChat Creator Companion user package. Without this change, it fails to parse the json and complains that the package is missing on every start.
The change is backwards compatible, as Unity also supports the object format for author: [link](https://docs.unity3d.com/Manual/upm-manifestPkg.html)

Not submitting to `develop` as I don't see package.json there, it looks manually maintained in main.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Update documentations
- [ ] Others (refactoring, style changes, etc.)

## Test environment

- Platform: Editor(Linux)
- Unity version: 2022.3.22f1
- Build options: N/A

## Checklist

- [ ] This pull request is for merging into the `develop` branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings